### PR TITLE
added: text display; prompt batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ follow the uv instalation guide then invoke the following command in your termin
 python3 -m entr_model_torch.main --config.prompt "Which number is larger 9.11 or 9.9? be brief in your response" --config.stream --config.debug
 ```
 
+You could also batch process prompts with the following example command:
+```sh
+python3 -m entr_model_torch.main --config.csv_file "prompts.csv" --config.no-stream --config.debug
+```
+
 the --help describes the cli args, here is the brief overview:
 
 ```sh
@@ -88,7 +93,10 @@ GenerateConfig Usage:
 --------------------
 Required:
 - prompt (str): The text prompt to generate from
-    Example: --prompt "Which number is larger 9.11 or 9.9? be brief in your response"
+    Example: --config.prompt "Once upon a time"
+OR
+- csv_file (str): path to csv file containing string prompts with column header 'prompts'
+    Example: --config.csv_file "prompts.csv"
 
 Optional:
 - max_tokens (int): How many tokens to generate (1-2048)
@@ -102,6 +110,8 @@ Optional:
     Usage: --config.stream or --config.no-stream
 
 Example usage:
-    python3 -m entr_model_torch.main --config.prompt "Which number is larger 9.11 or 9.9? be brief in your response" --config.no-stream --config.debug
+    python3 -m entr_model_torch.main --config.prompt "Which number is larger 9.11 or 9.9? be brief in your response" --config.stream --config.debug
+    or
+    python3 -m entr_model_torch.main --config.csv_file "prompts.csv" --config.no-stream --config.debug
 
 ```

--- a/entr_model_torch/config.py
+++ b/entr_model_torch/config.py
@@ -15,18 +15,22 @@ class GenerateConfig:
             Defaults to True.
         stream (bool, optional): Stream tokens as they're generated.
             Defaults to True.
+        csv_file (str, optional): Path to CSV file containing prompts.
+            Defaults to None.
     """
-    prompt: str
+    prompt: str = "Tell me a joke"
     max_tokens: Optional[int] = 600
     debug: bool = True
     stream: bool = True
+    csv_file: Optional[str] = None
 
     def __post_init__(self):
         """Validate inputs after initialization."""
-        if not isinstance(self.prompt, str):
-            raise ValueError("prompt must be a string")
-        if not self.prompt.strip():
-            raise ValueError("prompt cannot be empty")
+        if self.csv_file is None:
+            if not isinstance(self.prompt, str):
+                raise ValueError("prompt must be a string")
+            if not self.prompt.strip():
+                raise ValueError("prompt cannot be empty")
             
         if self.max_tokens is not None:
             if not isinstance(self.max_tokens, int):
@@ -42,7 +46,10 @@ GenerateConfig Usage:
 --------------------
 Required:
 - prompt (str): The text prompt to generate from
-    Example: --prompt "Once upon a time"
+    Example: --config.prompt "Once upon a time"
+OR
+- csv file (str): path to csv file containing string prompts with column header 'prompts'
+    Example: --config.csv_file "prompts.csv"
 
 Optional:
 - max_tokens (int): How many tokens to generate (1-2048)
@@ -57,6 +64,8 @@ Optional:
 
 Example usage:
     python3 -m entr_model_torch.main --config.prompt "Which number is larger 9.11 or 9.9? be brief in your response" --config.no-stream --config.debug
+    or
+    python3 -m entr_model_torch.main --config.csv_file "prompts.csv" --config.stream --config.debug
 """
 
 class EntropixConfig:

--- a/entr_model_torch/main.py
+++ b/entr_model_torch/main.py
@@ -508,7 +508,7 @@ class EntropixModel:
         # Add tokens
         formatted_text = ""
         line_length = 0
-        max_line_length = 275
+        max_line_length = 270 #some longer prompt overflow for some reason, keep it 270 for now
         
         for token, state in zip(token_texts, sampler_states):
             color = colors[state]
@@ -522,24 +522,8 @@ class EntropixModel:
             formatted_text += token_text
             line_length += len(token) + 1  # +1 for the space
         
-        # Add a box first (as background)
-        fig.add_shape(
-            type="rect",
-            xref="paper",
-            yref="paper",
-            x0=-0.01,  
-            y0=-0.01,
-            x1=1.01,
-            y1=0.08,  
-            line=dict(
-                color="gray",
-                width=1,
-            ),
-            fillcolor="white",
-            opacity=0.95
-        )
         
-        # Add the text on top of the box
+        # Add the text
         fig.add_annotation(
             text=formatted_text,
             xref="paper",
@@ -551,7 +535,7 @@ class EntropixModel:
             align="left",
             xanchor="left",
             yanchor="top",
-            xshift=10,
+            xshift=5,
             yshift=0, 
             bordercolor="gray",
             borderwidth=0,  

--- a/entr_model_torch/main.py
+++ b/entr_model_torch/main.py
@@ -494,7 +494,7 @@ class EntropixModel:
                 showticklabels=False,
                 range=[-0.5, 0.5]
             ),
-            height=1000,
+            height=750,
             showlegend=True,
             legend=dict(
                 yanchor="bottom",
@@ -508,7 +508,7 @@ class EntropixModel:
         # Add tokens
         formatted_text = ""
         line_length = 0
-        max_line_length = 270 #some longer prompt overflow for some reason, keep it 270 for now
+        max_line_length = 180 #some longer prompt overflow for some reason, keep it 270 for now
         
         for token, state in zip(token_texts, sampler_states):
             color = colors[state]
@@ -531,7 +531,7 @@ class EntropixModel:
             x=0,
             y=0.07,  
             showarrow=False,
-            font=dict(size=12),
+            font=dict(size=20),
             align="left",
             xanchor="left",
             yanchor="top",

--- a/prompts.csv
+++ b/prompts.csv
@@ -1,0 +1,4 @@
+"prompts"
+"Which number is larger 9.9 or 9.11? be very short in your response"
+"How many R in word strawberry?"
+"What is capital of France?"

--- a/uv.lock
+++ b/uv.lock
@@ -231,6 +231,7 @@ numpy==2.1.2
     #   jaxlib
     #   matplotlib
     #   ml-dtypes
+    #   pandas
     #   scipy
     #   transformers
 opt-einsum==3.4.0
@@ -249,6 +250,7 @@ packaging==24.1
     #   nbconvert
     #   plotly
     #   transformers
+pandas==2.2.3
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -294,8 +296,11 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   jupyter-client
     #   matplotlib
+    #   pandas
 python-json-logger==2.0.7
     # via jupyter-events
+pytz==2024.2
+    # via pandas
 pyyaml==6.0.2
     # via
     #   accelerate
@@ -423,6 +428,9 @@ typing-extensions==4.12.2
     #   torch
     #   tyro
 tyro==0.8.14
+    # via entropix-smollm
+tzdata==2024.2
+    # via pandas
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.3


### PR DESCRIPTION
added two things here

1. text display underneath the sampler metrics charts, coloured by sampler state
2. also added the capability to process prompts in batches, loaded from csv file. included and example prompts.csv for reference. 

both changes only impacts the cli. 

lastly, i've updated the uv.lock file to add pandas library to it (required for csv processing).